### PR TITLE
Open WebSocket dynamically with or without SSL

### DIFF
--- a/web/js/dungeon.js
+++ b/web/js/dungeon.js
@@ -488,7 +488,8 @@
     });
 
     // WebSocket
-    const socket = new WebSocket('ws://' + server_address + '/ws?clientId=' + client_id);
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const socket = new WebSocket(protocol + '//' + server_address + '/ws?clientId=' + client_id);
     socket.addEventListener('open', (event) => {
         console.log('Connected to the server');
     });


### PR DESCRIPTION
When running on 127.0.0.1 it will use ws:// but when running via a more public interface, if SSL is enabled it will use wss:// to load with SSL as to avoid mismatched protocol errors.